### PR TITLE
fixing test that causes author and title to be lost

### DIFF
--- a/js/epubjs.js
+++ b/js/epubjs.js
@@ -115,7 +115,7 @@ function opf(b) {
         a = a.text()
     }
     $("#content-title").html("<span class='title'>" + c + '</span> by <span class="author">' + a + "</span>");
-    if (c || c === "") {
+    if (!c || c === "") {
         $("#content-title").html("<span class='title'>" + $(b).find("dc\\:title").text() + '</span> by <span class="author">' + $(b).find("dc\\:creator").text() + "</span>")
     }
     var d = "opf\\:item";


### PR DESCRIPTION
The test that is changed is handing the situation where the "c" object doesn't exist, but the actual code was going in the "if" branch if the "c" object exists. This addresses issue #2 
Note: this test can actually be written as "if (!c)" using JavaScript's "truthy" concept, but I didn't want to change the existing coding style.
